### PR TITLE
Update: Change status text from 'Available for work' to 'Currently un…

### DIFF
--- a/src/components/ui/badge/status-badge.tsx
+++ b/src/components/ui/badge/status-badge.tsx
@@ -7,7 +7,7 @@ export default function StatusBadge() {
       <div className='flex items-center'>
         <AnimationAvailable />
       </div>
-      <h1>Available for work</h1>
+      <h1>Currently unavailable</h1>
     </div>
   );
 }


### PR DESCRIPTION
…available'

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the status badge text from `"Available for work"` to `"Currently unavailable"` in `status-badge.tsx`, reflecting a change in the author's current work availability.

- The text change itself is straightforward and correctly applied.
- **⚠️ Visual inconsistency**: The `AnimationAvailable` component (`available-animations.tsx`) still renders a bright **green pulsing circle** (`#15FF5B`), a conventional "online/available" indicator. Displaying this animation alongside `"Currently unavailable"` sends contradictory signals to visitors and should be addressed — either by updating the animation colour to reflect unavailability, or by swapping in a different visual indicator.

<h3>Confidence Score: 3/5</h3>

- Safe to merge functionally, but has a visible UX inconsistency that should be resolved before publishing.
- The change is a single-line text update with no risk of runtime errors. However, the green "available" animation is not updated to match the new "unavailable" text, producing a misleading badge that contradicts itself. This is a real UX issue rather than a blocking code defect, hence a mid-range score.
- src/components/ui/badge/status-badge.tsx and src/components/ui/available-animations.tsx need to be updated together to align the animation colour with the new unavailable status.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/ui/badge/status-badge.tsx | Status text updated to "Currently unavailable", but the accompanying green pulsing animation still visually signals an "available" state, creating a misleading UX mismatch. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Visitor
    participant SB as StatusBadge
    participant AA as AnimationAvailable (SVG)

    User->>SB: Views portfolio page
    SB->>AA: Renders green pulsing circle (#15FF5B)
    AA-->>User: 🟢 "Available" visual signal
    SB-->>User: Text label — "Currently unavailable"
    Note over User: ⚠️ Contradictory signals received
```

<sub>Last reviewed commit: ed6ba80</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->